### PR TITLE
Changes for docker-compose and gitlab-ci

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -25,4 +25,8 @@ curl -X POST \
   https://builder-dot-lighthouse-ci.appspot.com/ci
 ```
 
+```bash
+curl -i -H "Accept: application/json" -H "Content-Type: application/json" -X GET 'https://builder-dot-lighthouse-ci.appspot.com/stream?format=json&url=https://staging.example.com'
+```
+
 where `format` is one of `json`, `html`.

--- a/builder/README.md
+++ b/builder/README.md
@@ -26,7 +26,10 @@ curl -X POST \
 ```
 
 ```bash
-curl -i -H "Accept: application/json" -H "Content-Type: application/json" -X GET 'https://builder-dot-lighthouse-ci.appspot.com/stream?format=json&url=https://staging.example.com'
+curl -i \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
+  -X GET 'https://builder-dot-lighthouse-ci.appspot.com/stream?format=json&url=https://staging.example.com'
 ```
 
 where `format` is one of `json`, `html`.

--- a/builder/chromeuser-script.sh
+++ b/builder/chromeuser-script.sh
@@ -4,4 +4,5 @@
 nohup google-chrome \
   --headless \
   --disable-gpu \
+  --no-sandbox \
   --remote-debugging-port=9222 'about:blank' &

--- a/builder/docker_build.sh
+++ b/builder/docker_build.sh
@@ -4,4 +4,4 @@
 # docker build -t lighthouse_ci . --build-arg CACHEBUST=$(date +%d)
 
 # Build for non-headless Chrome version.
-docker build -f Dockerfile.nonheadless -t lighthouse_ci . --build-arg CACHEBUST=$(date +%d)
+docker build -f Dockerfile.headless -t lighthouse_ci . --build-arg CACHEBUST=$(date +%d)

--- a/builder/docker_run.sh
+++ b/builder/docker_run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run -d -p 8080:8080 --cap-add=SYS_ADMIN lighthouse_ci
+docker run -p 8080:8080 --cap-add=SYS_ADMIN lighthouse_ci

--- a/builder/server.js
+++ b/builder/server.js
@@ -58,7 +58,7 @@ function runLighthouseAsEventStream(req, res, next) {
   const file = `report.${Date.now()}.${extension}`;
   const fileSavePath = './reports/';
 
-  const args = [`--output-path=${fileSavePath + file}`, `--output=${format}`, '--port=9222'];
+  const args = [`--output-path=${fileSavePath + file}`, `--output=${format}`, '--chrome-flags="--headless"'];
   const child = spawn('lighthouse', [...args, url]);
 
   let log = '';

--- a/builder/server.js
+++ b/builder/server.js
@@ -19,7 +19,7 @@ function runLH(url, format = 'domhtml', res, next) {
   const file = `report.${Date.now()}.${extension}`;
   const fileSavePath = './reports/';
 
-  const args = [`--output-path=${fileSavePath + file}`, `--output=${format}`, '--port=9222', '--chrome-flags="--no-sandbox --headless"'];
+  const args = [`--output-path=${fileSavePath + file}`, `--output=${format}`, '--port=9222', '--chrome-flags="--remote-debugging-port=9222 --no-sandbox --headless"'];
   const child = spawn('lighthouse', [...args, url]);
 
   child.stderr.on('data', data => {
@@ -59,7 +59,7 @@ function runLighthouseAsEventStream(req, res, next) {
   const file = `report.${Date.now()}.${extension}`;
   const fileSavePath = './reports/';
 
-  const args = [`--output-path=${fileSavePath + file}`, `--output=${format}`, '--port=9222', '--chrome-flags="--no-sandbox --headless"'];
+  const args = [`--output-path=${fileSavePath + file}`, `--output=${format}`, '--port=9222', '--chrome-flags="--remote-debugging-port=9222 --no-sandbox --headless"'];
   const child = spawn('lighthouse', [...args, url]);
 
   let log = 'lighthouse ' + args.join(' ') + ' ' + url + '\n';

--- a/builder/server.js
+++ b/builder/server.js
@@ -17,8 +17,9 @@ function runLH(url, format = 'domhtml', res, next) {
 
   const extension = format === 'domhtml' ? 'html' : format;
   const file = `report.${Date.now()}.${extension}`;
+  const fileSavePath = './reports/';
 
-  const args = [`--output-path=${file}`, `--output=${format}`, '--port=9222'];
+  const args = [`--output-path=${fileSavePath + file}`, `--output=${format}`, '--port=9222', '--chrome-flags="--no-sandbox --headless"'];
   const child = spawn('lighthouse', [...args, url]);
 
   child.stderr.on('data', data => {
@@ -58,10 +59,10 @@ function runLighthouseAsEventStream(req, res, next) {
   const file = `report.${Date.now()}.${extension}`;
   const fileSavePath = './reports/';
 
-  const args = [`--output-path=${fileSavePath + file}`, `--output=${format}`, '--chrome-flags="--headless"'];
+  const args = [`--output-path=${fileSavePath + file}`, `--output=${format}`, '--port=9222', '--chrome-flags="--no-sandbox --headless"'];
   const child = spawn('lighthouse', [...args, url]);
 
-  let log = '';
+  let log = 'lighthouse ' + args.join(' ') + ' ' + url + '\n';
 
   child.stderr.on('data', data => {
     const str = data.toString();

--- a/builder/server.js
+++ b/builder/server.js
@@ -19,7 +19,7 @@ function runLH(url, format = 'domhtml', res, next) {
   const file = `report.${Date.now()}.${extension}`;
   const fileSavePath = './reports/';
 
-  const args = [`--output-path=${fileSavePath + file}`, `--output=${format}`, '--port=9222', '--chrome-flags="--remote-debugging-port=9222 --no-sandbox --headless"'];
+  const args = [`--output-path=${fileSavePath + file}`, `--output=${format}`, '--port=9222'];
   const child = spawn('lighthouse', [...args, url]);
 
   child.stderr.on('data', data => {
@@ -59,7 +59,7 @@ function runLighthouseAsEventStream(req, res, next) {
   const file = `report.${Date.now()}.${extension}`;
   const fileSavePath = './reports/';
 
-  const args = [`--output-path=${fileSavePath + file}`, `--output=${format}`, '--port=9222', '--chrome-flags="--remote-debugging-port=9222 --no-sandbox --headless"'];
+  const args = [`--output-path=${fileSavePath + file}`, `--output=${format}`, '--port=9222'];
   const child = spawn('lighthouse', [...args, url]);
 
   let log = 'lighthouse ' + args.join(' ') + ' ' + url + '\n';

--- a/builder/server.js
+++ b/builder/server.js
@@ -70,7 +70,7 @@ function runLighthouseAsEventStream(req, res, next) {
   });
 
   child.on('close', statusCode => {
-    const serverOrigin = `https://${req.host}/`;
+    const serverOrigin = `http://${req.host}:${PORT}/`;
     res.write(`data: done ${serverOrigin + file}\n\n`);
     res.status(410).end();
     console.log(log);


### PR DESCRIPTION
These changes allowed me to get your lighthouse-ci image working locally and on gitlab-ci using these files in my own project:

**Docker Compose**

docker-compose.yml
```
version: "2"
services:
  backend:
    build: ./backend
    command: python server.py
    environment:
      NODE_ENV: development
    networks:
      - backend
    ports:
      - '3000:3000'
    volumes:
      - ./backend:/usr/src/app:ro
  lighthouse:
    image: kmturley/lighthouse-ci
    networks:
      - backend
    ports:
      - "8080:8080"
networks:
  backend:
    driver: bridge
```

qa/page_runner.py
```
import os, requests, json, re
BASE_URL = os.getenv('BASE_URL', 'https://localhost:3000')
LIGHTHOUSE_IMAGE = os.getenv('LIGHTHOUSE_IMAGE', 'http://localhost:8080')
headers = {
  'Accept-Charset': 'UTF-8',
  'Content-Type': 'application/json',
  'X-API-KEY': '<YOUR_API_KEY>'
}

# r = requests.post(LIGHTHOUSE_IMAGE + '/ci', data='{"format": "json", "url": "' + BASE_URL + '"}', headers=headers)
r = requests.get(LIGHTHOUSE_IMAGE + '/stream?format=json&url=' + BASE_URL, headers=headers)

urls = re.findall('http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', r.text)
print (urls)

req = requests.get(urls[0], headers=headers)
data = req.json()
directory = 'qa/output';
if not os.path.exists(directory):
    os.makedirs(directory)
with open(directory + 'index.report.json', 'w') as f:
    json.dump(data, f)
print ('copied to: ' + directory + 'index.report.json')
```

**Gitlab CI**

.gitlab-ci.yml
```
test_accessibility:
  image: python
  stage: test
  services:
  - name: kmturley/lighthouse-ci
  script:
    - pip install -r requirements.txt
    - BASE_URL="https://$CI_BUILD_REF_SLUG-dot-$GAE_PROJECT.appspot.com" LIGHTHOUSE_IMAGE="http://kmturley__lighthouse-ci:8080" python qa/page_runner.py
```