### PR TITLE
Rename environment variable from API_KEY to LIGHTHOUSE_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ First, add [lighthousebot](https://github.com/lighthousebot) as a collaborator o
 [Request an API Key](https://goo.gl/forms/9BzzhHd1sKzsvyC52). API keys will eventually be
 enforced and are necessary so we can contact you when there are changes to the CI system.
 
-Once you have a key, update Travis settings by adding an `API_KEY` environment variables with your key:
+Once you have a key, update Travis settings by adding an `LIGHTHOUSE_API_KEY` environment variables with your key:
 
-<img width="875" alt="Travis API_KEY env variable " src="https://user-images.githubusercontent.com/238208/27442363-d6329098-5724-11e7-848e-a46c76b1a047.png">
+<img width="875" alt="Travis LIGHTHOUSE_API_KEY env variable " src="https://user-images.githubusercontent.com/2837064/32105842-2635de42-bb2a-11e7-983a-921a802d38b3.jpg">
 
 The `runlighthouse.js` script will include your key in requests made to the CI server.
 
@@ -147,7 +147,7 @@ REST endpoints:
 ```
 POST https://lighthouse-ci.appspot.com/run_on_chrome
 Content-Type: application/json
-X-API-KEY: <YOUR_API_KEY>
+X-API-KEY: <YOUR_LIGHTHOUSE_API_KEY>
 
 {
   testUrl: "https://staging.example.com",
@@ -181,7 +181,7 @@ REST endpoints:
 ```bash
 curl -X POST \
   -H "Content-Type: application/json" \
-  -H "X-API-KEY: <YOUR_API_KEY>" \
+  -H "X-API-KEY: <YOUR_LIGHTHOUSE_API_KEY>" \
   --data '{"format": "json", "url": "https://staging.example.com"}' \
   https://builder-dot-lighthouse-ci.appspot.com/ci
 ```

--- a/builder/README.md
+++ b/builder/README.md
@@ -28,7 +28,7 @@ Be sure Docker is running, then run:
 ```bash
 curl -X POST \
   -H "Content-Type: application/json" \
-  -H "X-API-KEY: <YOUR_API_KEY>" \
+  -H "X-API-KEY: <YOUR_LIGHTHOUSE_API_KEY>" \
   --data '{"format": "json", "url": "https://staging.example.com"}' \
   https://localhost:8080/ci
 ```

--- a/runlighthouse.js
+++ b/runlighthouse.js
@@ -19,8 +19,14 @@ const fetch = require('node-fetch'); // polyfill
 const minimist = require('minimist');
 
 const CI_HOST = process.env.CI_HOST || 'https://lighthouse-ci.appspot.com';
-const API_KEY = process.env.API_KEY;
+const API_KEY = process.env.LIGHTHOUSE_API_KEY || process.env.API_KEY;
 const RUNNERS = {chrome: 'chrome', wpt: 'wpt'};
+
+if (process.env.API_KEY) {
+  console.log('Warning:
+The environment variable API_KEY is deprecated.
+Please use LIGHTHOUSE_API_KEY instead.');
+}
 
 function printUsageAndExit() {
   const usage = `Usage:

--- a/runlighthouse.js
+++ b/runlighthouse.js
@@ -23,9 +23,7 @@ const API_KEY = process.env.LIGHTHOUSE_API_KEY || process.env.API_KEY;
 const RUNNERS = {chrome: 'chrome', wpt: 'wpt'};
 
 if (process.env.API_KEY) {
-  console.log('Warning:
-The environment variable API_KEY is deprecated.
-Please use LIGHTHOUSE_API_KEY instead.');
+  console.log('Warning: The environment variable API_KEY is deprecated. Please use LIGHTHOUSE_API_KEY instead.');
 }
 
 function printUsageAndExit() {


### PR DESCRIPTION
Since lighthouse might not be the only one using the environment variable `API_KEY` it would be better to namespace this variable to `LIGHTHOUSE_API_KEY`