### PR TITLE
fix: run endpoint with output json by default

### DIFF
--- a/frontend/server.js
+++ b/frontend/server.js
@@ -136,7 +136,9 @@ app.post('/run_on_wpt', async (req, res) => {
 
 // Handler to start Lighthouse run on Chrome.
 app.post('/run_on_chrome', async (req, res) => {
-  const config = Object.assign({}, req.body);
+  const config = Object.assign({
+    output: 'json'
+  }, req.body);
 
   const prInfo = {
     repo: config.repo.name,


### PR DESCRIPTION
https://lighthouse-ci.appspot.com/run_on_chrome it was failing if output is not provided. So now it works by set `output` property to `json` by default.

This didn't work:
```
curl --request POST \
  --url https://lighthouse-ci.appspot.com/run_on_chrome \
  --header 'content-type: application/json' \
  --header 'x-api-key: <key>' \
  --data '{
  "testUrl": "<test>",
  "addComment": false,
  "repo": {
    "owner": "<owner>",
    "name": "<name>"
  },
  "pr": {
    "number": "<pr>"
  }
}'
```

With this PR it does. 