### PR TITLE
fix dockerfile

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -3,7 +3,7 @@ FROM node:10-slim
 LABEL maintainer="Eric Bidelman <ebidel@>"
 
 # Install utilities
-RUN apt-get update --fix-missing && apt-get -y upgrade
+RUN apt-get update --fix-missing && apt-get -y upgrade && apt-get install -y wget gnupg
 
 # Install latest chrome dev package.
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \


### PR DESCRIPTION
Building the docker image at the moment results in 2 problems:

1. Missing wget

```
Step 4/19 : RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'     && apt-get update     && apt-get install -y google-chrome-unstable --no-install-recommends     && rm -rf /var/lib/apt/lists/*     && rm -rf /src/*.deb
 ---> Running in e1277d4915b0
/bin/sh: 1: wget: not found
```

2. missing gnupg

```
gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation
```

So I installed them both and it seems to be working:

```
Step 17/19 : ENV CI=true
 ---> Running in 9b5cf80f2976
Removing intermediate container 9b5cf80f2976
 ---> ce4ba8d415fa
Step 18/19 : EXPOSE 8080
 ---> Running in 65481787df9d
Removing intermediate container 65481787df9d
 ---> 6f1602c1dbde
Step 19/19 : ENTRYPOINT ["dumb-init", "--", "/entrypoint.sh"]
 ---> Running in 5ede837acdd5
Removing intermediate container 5ede837acdd5
 ---> 44e2ebe1308c
Successfully built 44e2ebe1308c
```